### PR TITLE
Made it work with the device with ID 0x5408

### DIFF
--- a/examples/Touch_shield_kbv/Touch_shield_kbv.ino
+++ b/examples/Touch_shield_kbv/Touch_shield_kbv.ino
@@ -128,7 +128,6 @@ void show_tft(void)
 void setup(void)
 {
     uint16_t tmp;
-    tft.begin(9600);
 
     tft.reset();
     identifier = tft.readID();
@@ -184,6 +183,10 @@ void setup(void)
     } else if (identifier == 0xB509) {
         name = "R61509V";
         TS_LEFT = 889; TS_RT = 149; TS_TOP = 106; TS_BOT = 975;
+        SwapXY = 1;
+    } else if (identifier == 0x5408) {
+        name = "5408";
+        TS_LEFT = 150; TS_RT = 960; TS_TOP = 155; TS_BOT = 925;
         SwapXY = 1;
     } else {
         name = "unknown";


### PR DESCRIPTION
The tft.begin(9600) was causing white blank screen here. Also added the calibration values for 0x5408, which is this device: https://www.aliexpress.com/item/Free-shipping-LCD-module-TFT-2-4-inch-TFT-LCD-screen-for-Arduino-UNO-R3-Board/32583491591.html