### PR TITLE
Enable default support 8230

### DIFF
--- a/MCUFRIEND_kbv.cpp
+++ b/MCUFRIEND_kbv.cpp
@@ -7,7 +7,7 @@
 #define SUPPORT_4535              //LGDP4535 +180 bytes
 #define SUPPORT_68140             //RM68140 +52 bytes defaults to PIXFMT=0x55
 #define SUPPORT_7781              //ST7781 +172 bytes
-//#define SUPPORT_8230              //UC8230 +118 bytes
+#define SUPPORT_8230              //UC8230 +118 bytes
 //#define SUPPORT_8347D             //HX8347-D, HX8347-G, HX8347-I, HX8367-A +520 bytes, 0.27s
 //#define SUPPORT_8347A             //HX8347-A +500 bytes, 0.27s
 //#define SUPPORT_8352A             //HX8352A +486 bytes, 0.27s

--- a/README.md
+++ b/README.md
@@ -1,30 +1,32 @@
-#MCUFRIEND_kbv 
-Library for Uno 2.4, 2.8, 3.5, 3.6, 3.95 inch mcufriend  Shields
+# MCUFRIEND_kbv
+_Library for Uno 2.4, 2.8, 3.5, 3.6, 3.95 inch mcufriend Shields_
 
-1. The Arduino Library Manager should find and install MCUFRIEND_kbv library
+The Arduino Library Manager should find and install MCUFRIEND_kbv library for you.
 
-2. Install the Adafruit_GFX library if not already in your User libraries.
+1. Install the Adafruit_GFX library if not already in your User libraries.
 
-3. Insert your Mcufriend style display shield into UNO.   Only 28-pin shields are supported.
+2. Insert your Mcufriend style display shield into UNO.   Only 28-pin shields are supported.
 
-4. Build any of the Examples from the File->Examples->Mcufriend_kbv menu.  e.g.
+3. Build any of the Examples from the File->Examples->Mcufriend_kbv menu.  e.g.
+ * `graphictest_kbv.ino`: shows all the methods.
+ * `LCD_ID_readreg.ino`:  diagnostic check to identify unsupported controllers.
 
-graphictest_kbv.ino: shows all the methods.
-
-LCD_ID_readreg.ino:  diagnostic check to identify unsupported controllers.
-
-MCUFRIEND_kbv inherits all the methods from 
-the Adafruit_GFX class: https://learn.adafruit.com/adafruit-gfx-graphics-library/overview 
+MCUFRIEND_kbv inherits all the methods from
+the Adafruit_GFX class: https://learn.adafruit.com/adafruit-gfx-graphics-library/overview
 and Print class: https://www.arduino.cc/en/Serial/Print
 
-The only "new" methods are hardware related: 
-vertScroll(), readGRAM(), readPixel(), setAddrWindow(), pushColors(), readID(), begin()
+The only "new" methods are hardware related:
+`vertScroll()`, `readGRAM()`, `readPixel()`, `setAddrWindow()`, `pushColors()`, `readID()`, `begin()`
 
-readReg(), pushCommand() access the controller registers
+Use `readReg()`, `pushCommand()` to access the controller registers
 
+#### Note
 The File layout changed with v2.9.3.   If replacing a pre-v2.9.3 library:
-Please leave IDE.  Delete the existing MCUFRIEND_kbv folder.  Start the IDE.  Install from Library Manager.
+1. Please leave IDE.  Delete the existing MCUFRIEND_kbv folder.
+2. Start the IDE.  Install from Library Manager.
 
-HOW TO INSTALL AND USE: is now in "mcufriend_how_to.txt"
+#### HOW TO INSTALL AND USE:
+is now in "mcufriend_how_to.txt"
 
-CHANGE HISTORY:         is now in "mcufriend_history.txt"
+#### CHANGE HISTORY:         
+is now in "mcufriend_history.txt"

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ The Arduino Library Manager should find and install MCUFRIEND_kbv library for yo
 2. Insert your Mcufriend style display shield into UNO.   Only 28-pin shields are supported.
 
 3. Build any of the Examples from the File->Examples->Mcufriend_kbv menu.  e.g.
- * `graphictest_kbv.ino`: shows all the methods.
- * `LCD_ID_readreg.ino`:  diagnostic check to identify unsupported controllers.
+    * `graphictest_kbv.ino`: shows all the methods.
+    * `LCD_ID_readreg.ino`:  diagnostic check to identify unsupported controllers.
 
 MCUFRIEND_kbv inherits all the methods from
 the Adafruit_GFX class: https://learn.adafruit.com/adafruit-gfx-graphics-library/overview


### PR DESCRIPTION
I'm acting on behalf of an electronics store in Australia.

We sell a lot of screens that use the 8230 chipset, and this library is by far the best library to use for our needs.

We'd like to enable 8230 support in the master branch so that when the changes are reflected in the Arduino library manager, we can direct people to use your library quickly and easily.

A lot of our customers (primary and secondary students) aren't comfortable with modifying libraries and have a hard time installing libraries from zip files. They also don't understand where the libraries go after using the library manager.

enabling this change only adds 118 bytes and I am more than certain that a less-common driver could be commented out without concern if size is an issue.

